### PR TITLE
Fix Debian packaging with Meson

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 4.2.1
 Build-Depends:
     meson (>= 0.50.0),
     cppcheck,
-    debhelper-compat (= 11),
+    debhelper-compat (= 12),
     dh-exec,
     libc6-dev (>= 2.26),
     libcurl4-openssl-dev,
@@ -19,7 +19,7 @@ Build-Depends:
     valgrind
 Vcs-Git: https://github.com/pistacheio/pistache.git
 Vcs-browser: https://github.com/pistacheio/pistache
-Homepage: https://github.com/pistacheio/pistache
+Homepage: http://pistache.io
 
 Package: libpistache-dev
 Architecture: any

--- a/debian/libpistache-dev.install
+++ b/debian/libpistache-dev.install
@@ -1,5 +1,4 @@
+usr/include
 usr/lib/*/pkgconfig
-usr/lib/*/cmake
-usr/include usr
 usr/lib/*/libpistache*.a
 usr/lib/*/libpistache*.so

--- a/debian/libpistache0.install
+++ b/debian/libpistache0.install
@@ -1,2 +1,1 @@
 usr/lib/*/libpistache*.so.*
-

--- a/debian/rules
+++ b/debian/rules
@@ -12,20 +12,22 @@ export DH_OPTIONS=-v
 # Set flags for how the package will be compiled and built. Note separated with
 #  white space and not comma, as per DPM § 4.9.1...
 
-    # Set various group related security hardening build flags for format,
-    #  fortify, stackprotector, relro, bindnow, and pie...
-    DH_BUILD_MAINT_OPTIONS  = hardening=+all
+# Set various group related security hardening build flags for format,
+#  fortify, stackprotector, relro, bindnow, and pie...
+DH_BUILD_MAINT_OPTIONS  = hardening=+all
 
-    # Skip unit testing...
-    #DH_BUILD_MAINT_OPTIONS += nocheck
+# Skip unit testing...
+#DH_BUILD_MAINT_OPTIONS += nocheck
 
-    # The above should be reflected when dpkg-buildflags is called and merged
-    #  with the defaults...
-    export DH_BUILD_MAINT_OPTIONS
-    export DPKG_EXPORT_BUILDFLAGS = 1
+# The above should be reflected when dpkg-buildflags is called and merged
+#  with the defaults...
+export DH_BUILD_MAINT_OPTIONS
 
+# Should be avoided since debhelper 9
+# https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#variablesrules
+# export DPKG_EXPORT_BUILDFLAGS = 1
 # Standard rules and preset shell variables...
-include /usr/share/dpkg/default.mk
+# include /usr/share/dpkg/default.mk
 
 # Directory containing package since may not be called from current working
 #  directory. MAKEFILE_LIST pre-defined by Make and appended each time another
@@ -42,80 +44,49 @@ SOURCE_DIR  = $(abspath $(PACKAGE_DIR)/../)
 
 # Configure source...
 override_dh_auto_configure:
-	dh_auto_configure --                                                        \
-	    --buildtype=release                                                     \
-	    -DPISTACHE_BUILD_EXAMPLES=true                                          \
-	    -DPISTACHE_BUILD_TESTS=true                                             \
-	    -DPISTACHE_ENABLE_NETWORK_TESTS=false                                   \
-	    -DPISTACHE_BUILD_DOCS=false                                             \
-	    -DPISTACHE_USE_SSL=true                                                 \
-	    --prefix=/usr                                                           \
-	    $(SOURCE_DIR)
+	dh_auto_configure --														\
+		-DPISTACHE_BUILD_EXAMPLES=true											\
+		-DPISTACHE_BUILD_TESTS=true												\
+		-DPISTACHE_ENABLE_NETWORK_TESTS=false									\
+		-DPISTACHE_BUILD_DOCS=false												\
+		-DPISTACHE_USE_SSL=true													\
 
-# Perform unit testing, but only if not disabled...
-ifeq (,$(findstring nocheck,$(DEB_BUILD_OPTIONS)))
-override_dh_auto_test:
-ifeq "$(DEB_BUILD_ARCH)" "armhf"
-	@echo "# Performing unit tests, but skipping memcheck because valgrind broken on this platform..."
-	dh_auto_test -- test || { find . -iname "LastTest.log" -exec cat {} \; ; exit 99; }
-else
-	@echo "# Performing all unit tests..."
-	dh_auto_test -- test test_memcheck || { find . -iname "LastTest.log" -exec cat {} \; ; exit 99; }
-endif
-endif
+# It is pointless to customize the tests until we upgrade to debhelper-compat 13,
+# because debhelper 12 runs ninja test instead of meson test, and --wrap=valgrind
+# is only supported by the latter.
+#override_dh_auto_test:
+#ifeq "$(DEB_BUILD_ARCH)" "armhf"
+#	@echo "# Performing unit tests, but skipping valgrind because it is broken on this platform..."
+#	dh_auto_test
+#else
+#	@echo "# Performing all unit tests..."
+#	dh_auto_test -- --wrap=valgrind
+#endif
 
+# get-orig-source is deprecated since version 4.1.4 of the Debian Policy
 # Prepare an upstream vanilla distribution tarball as per DPM § 4.9...
 #  http://wiki.debian.org/onlyjob/get-orig-source
-get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.bz2 $(info I: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM))
+get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz $(info I: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM))
 	@
 
-## Prepare an upstream vanilla distribution tarball...
-#$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.bz2:
-#	@echo "# Preparing source for $(DEB_SOURCE) v$(DEB_VERSION_UPSTREAM)..."
-#	cd $(SOURCE_DIR)                                                            \
-#	&& cd $(PACKAGE_DIR)                                                        \
-#	&& mkdir -p $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)                           \
-#	&& cd $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)                                 \
-#	&& cmake                                                                    \
-#		-G "Unix Makefiles"                                                     \
-#		-DCMAKE_BUILD_TYPE=Release                                              \
-#		-DPISTACHE_BUILD_EXAMPLES=true                                          \
-#		-DPISTACHE_BUILD_TESTS=true                                             \
-#	    -DPISTACHE_ENABLE_NETWORK_TESTS=false                                   \
-#		-DPISTACHE_BUILD_DOCS=false                                             \
-#	    -DPISTACHE_USE_SSL=true                                                 \
-#		-DCMAKE_INSTALL_PREFIX=/usr                                             \
-#		$(SOURCE_DIR)                                                           \
-#	&& make dist                                                                \
-#	&& mv -v $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.bz2 $(SOURCE_DIR)/../$@
-#	@echo "# Cleaning up..."
-#	cd $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)                     \
-#	&& make clean
-#	cd $(PACKAGE_DIR)                                                           \
-#	&& $(RM) -r $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
-
 # Prepare an upstream vanilla distribution tarball...
-$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.bz2:
+$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz:
 	@echo "# Preparing source for $(DEB_SOURCE) v$(DEB_VERSION_UPSTREAM)..."
-	cd $(SOURCE_DIR)                                                            \
-	&& cd $(PACKAGE_DIR)                                                        \
-	&& meson setup $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)                        \
-		--buildtype=release                                                     \
-		-DPISTACHE_BUILD_EXAMPLES=true                                          \
-		-DPISTACHE_BUILD_TESTS=true                                             \
-	    -DPISTACHE_ENABLE_NETWORK_TESTS=false                                   \
-		-DPISTACHE_BUILD_DOCS=false                                             \
-	    -DPISTACHE_USE_SSL=true                                                 \
-		--prefix=/usr                                                           \
-	&& cd $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)                                 \
-	&& ninja dist                                                               \
-	&& rm meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.xz.sha256sum     \
-	&& mv -v meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.xz $(SOURCE_DIR)/../$@
+	cd $(SOURCE_DIR)															\
+	&& cd $(PACKAGE_DIR)														\
+	&& meson setup $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)						\
+		--buildtype=release														\
+		-DPISTACHE_BUILD_EXAMPLES=true											\
+		-DPISTACHE_BUILD_TESTS=true												\
+		-DPISTACHE_ENABLE_NETWORK_TESTS=false									\
+		-DPISTACHE_BUILD_DOCS=false												\
+		-DPISTACHE_USE_SSL=true													\
+		--prefix=/usr															\
+		--wrap-mode=nodownload													\
+	&& meson dist -C $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) --no-tests			\
+	&& mv -v $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.xz $(SOURCE_DIR)/../$@
 	@echo "# Cleaning up..."
-	cd $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)                     \
-	&& ninja clean
-	cd $(PACKAGE_DIR)                                                           \
-	&& $(RM) -r $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
+	$(RM) -r $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
 
 # Targets which aren't actual products...
-.PHONY: get-orig-source override_dh_auto_configure override_dh_auto_test
+.PHONY: get-orig-source override_dh_auto_configure# override_dh_auto_test

--- a/debian/rules
+++ b/debian/rules
@@ -25,9 +25,8 @@ export DH_BUILD_MAINT_OPTIONS
 
 # Should be avoided since debhelper 9
 # https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#variablesrules
-export DPKG_EXPORT_BUILDFLAGS = 1
-# Standard rules and preset shell variables...
-include /usr/share/dpkg/default.mk
+# Including only the necessary variables
+include /usr/share/dpkg/pkg-info.mk
 
 # Directory containing package since may not be called from current working
 #  directory. MAKEFILE_LIST pre-defined by Make and appended each time another
@@ -66,16 +65,18 @@ override_dh_auto_configure:
 # get-orig-source is deprecated since version 4.1.4 of the Debian Policy
 # Prepare an upstream vanilla distribution tarball as per DPM § 4.9...
 #  http://wiki.debian.org/onlyjob/get-orig-source
-get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz $(info I: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM))
+get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz $(info I: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM))
 	@
 
 # Prepare an upstream vanilla distribution tarball...
-$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz:
+# meson dist does not include .github in the source tarball (mesonbuild/meson#8541)
+# so it is necessary to manually add the folder to the archive
+$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz:
 	@echo "# Preparing source for $(DEB_SOURCE) v$(DEB_VERSION_UPSTREAM)..."
 	cd $(SOURCE_DIR)															\
 	&& cd $(PACKAGE_DIR)														\
 	&& meson setup $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) ..						\
-		--buildtype=release														\
+		--buildtype=plain														\
 		-DPISTACHE_BUILD_EXAMPLES=true											\
 		-DPISTACHE_BUILD_TESTS=true												\
 		-DPISTACHE_ENABLE_NETWORK_TESTS=false									\
@@ -83,10 +84,16 @@ $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz:
 		-DPISTACHE_USE_SSL=true													\
 		--prefix=/usr															\
 		--wrap-mode=nodownload													\
-	&& meson dist -C $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) --no-tests			\
-	&& mv -v $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.xz $(SOURCE_DIR)/../$@
+	&& meson dist -C $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) --no-tests --formats=gztar	\
+	&& cd $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)					\
+	&& mkdir $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM)								\
+	&& cp -r $(SOURCE_DIR)/.github $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM)		\
+	&& gunzip $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.gz						\
+	&& tar --append --file=$(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM)/.github	\
+	&& gzip $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar							\
+	&& mv $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.gz $(SOURCE_DIR)/../$@
 	@echo "# Cleaning up..."
-	$(RM) -r $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
+	$(RM) -r $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
 
 # Targets which aren't actual products...
 .PHONY: get-orig-source override_dh_auto_configure# override_dh_auto_test

--- a/debian/rules
+++ b/debian/rules
@@ -25,9 +25,9 @@ export DH_BUILD_MAINT_OPTIONS
 
 # Should be avoided since debhelper 9
 # https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#variablesrules
-# export DPKG_EXPORT_BUILDFLAGS = 1
+export DPKG_EXPORT_BUILDFLAGS = 1
 # Standard rules and preset shell variables...
-# include /usr/share/dpkg/default.mk
+include /usr/share/dpkg/default.mk
 
 # Directory containing package since may not be called from current working
 #  directory. MAKEFILE_LIST pre-defined by Make and appended each time another
@@ -74,7 +74,7 @@ $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz:
 	@echo "# Preparing source for $(DEB_SOURCE) v$(DEB_VERSION_UPSTREAM)..."
 	cd $(SOURCE_DIR)															\
 	&& cd $(PACKAGE_DIR)														\
-	&& meson setup $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)						\
+	&& meson setup $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) ..						\
 		--buildtype=release														\
 		-DPISTACHE_BUILD_EXAMPLES=true											\
 		-DPISTACHE_BUILD_TESTS=true												\

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,3 +1,0 @@
-pistache source: source-is-missing assets/js/jquery.min.js
-pistache source: source-is-missing assets/js/modernizr.js line length is 8708 characters (>512)
-

--- a/debian/watch
+++ b/debian/watch
@@ -1,4 +1,3 @@
 version=4
-opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.bz2/pistache-$1\.tar\.bz2/ \
-  https://github.com/pistacheio/pistache/tags .*/?(\d+\.\d+.\d+)\.tar\.bz2
-
+opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/pistache-$1\.tar\.gz/ \
+  https://github.com/pistacheio/pistache/tags .*/v?(\d\S*)\.tar\.gz

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,5 +1,4 @@
-rapidjson = subproject('rapidjson')
-rapidjson_dep = dependency('rapidjson', fallback: ['rapidjson', 'rapidjson_dep'], required: true)
+rapidjson_dep = dependency('RapidJSON', fallback: ['rapidjson', 'rapidjson_dep'], required: true)
 
 pistache_example_files = [
 	'custom_header',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'pistache',
 	'cpp',
-	version: '0.0.2',
+	version: '0.0.002',
 	license: 'Apache-2.0',
 	default_options: [
 		'cpp_std=c++17',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'pistache',
 	'cpp',
-	version: '0.0.0',
+	version: '0.0.2',
 	license: 'Apache-2.0',
 	default_options: [
 		'cpp_std=c++17',

--- a/meson.build
+++ b/meson.build
@@ -93,7 +93,7 @@ endforeach
 pistache_version_str = '.'.join([version_data_conf.get_unquoted('VERSION_MAJOR'), version_data_conf.get_unquoted('VERSION_MINOR'), version_data_conf.get_unquoted('VERSION_PATCH')])
 pistache_soversion_str = '.'.join([version_data_conf.get_unquoted('SONAME_VERSION_MAJOR'), version_data_conf.get_unquoted('SONAME_VERSION_MINOR')])
 
-configure_file(input: 'libpistache.pc.in', output: 'libpistache.pc', install: get_option('PISTACHE_INSTALL'), install_dir: get_option('includedir')/'pistache', configuration: {
+configure_file(input: 'libpistache.pc.in', output: 'libpistache.pc', install: get_option('PISTACHE_INSTALL'), install_dir: get_option('libdir')/'pkgconfig', configuration: {
 	'prefix': prefix,
 	'exec_prefix': prefix/get_option('bindir'),
 	'libdir': prefix/get_option('libdir'),


### PR DESCRIPTION
Now the package is built with Meson. I've updated the `debhelper-compat` version to 12 since it provides good support for Meson, I've removed the lintian overrides (useless since the migration to Docusaurus), and obviously updated `debian/rules` to use Meson for building the package and creating the tarball. 

This is not perfect though, as I had to use an ugly hack for the tarball since Meson does not add `.github` to the archive (mesonbuild/meson#8541).
Also, it is not possible to run the tests with valgrind since debhelper 12 uses `ninja test` for testing (while it should use `meson test`, so that one could add `--wrap=valgrind`). This behavior is corrected in debhelper 13, but it is too recent and not available in Ubuntu 20.04. It would be also possible to completely override `dh_auto_test`, but I don't think that's worth it.

`autopkgtest` does not report any error in Ubuntu Focal, so I think that everything is ok :)