### PR TITLE
ci: add conventional commits check

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: conventional-commits
+
+on: pull_request
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ github.event.pull_request.commits }} + 1
+
+      - uses: actions/setup-node@v2
+
+      - name: Install commitlint cli
+        run: |
+          yarn global add @commitlint/cli @commitlint/config-conventional
+          echo "module.exports = { extends: ['@commitlint/config-conventional'] }" > commitlint.config.js
+
+      - name: Commitlint
+        run: commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD


### PR DESCRIPTION
Conventional Commits is a specification that aims at improving commit messages and history.

It consists of a simple canonical format for commit messages:
type(optional scope): description

Having a small list of types helps understand when a change is breaking, when it adds a feature, where it patches something, or when it is unrelated to the main library (build system changes, CI, tests...).

This is really useful when determing when to release and what type of release should be made (major, minor, or patch release).